### PR TITLE
Tell users they can use SITE variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You need to setup few environment variables in order to make the client work. Yo
     export OAUTH2_CLIENT_ID           = "129477f..."
     export OAUTH2_CLIENT_SECRET       = "c1eec90..."
     export OAUTH2_CLIENT_REDIRECT_URI = "http://localhost:9393/callback"
+    export SITE = "http://you-server-app.com"
 
 
 or set them in a file named `env.rb` in the app's root. This file is loaded automatically by the app.
@@ -37,6 +38,7 @@ or set them in a file named `env.rb` in the app's root. This file is loaded auto
     ENV['OAUTH2_CLIENT_ID']           = "129477f..."
     ENV['OAUTH2_CLIENT_SECRET']       = "c1eec90..."
     ENV['OAUTH2_CLIENT_REDIRECT_URI'] = "http://localhost:9393/callback"
+    ENV['SITE']                       = "http://you-server-app.com"
 
 ## Start the server
 


### PR DESCRIPTION
If user wants to test its own OAuth2 implementation he should update SITE env variable.
It wasn't mentioned in docs.
